### PR TITLE
Expanding supported DateTime parsing formats

### DIFF
--- a/src/MixERP.Net.VCards/Processors/DateTimeProcessor.cs
+++ b/src/MixERP.Net.VCards/Processors/DateTimeProcessor.cs
@@ -1,12 +1,42 @@
-﻿using System;
-using System.Globalization;
-using MixERP.Net.VCards.Serializer;
+﻿using MixERP.Net.VCards.Serializer;
 using MixERP.Net.VCards.Types;
+using System;
+using System.Globalization;
 
 namespace MixERP.Net.VCards.Processors
 {
     public static class DateTimeProcessor
     {
+        /// <summary>
+        /// Includes DATE-AND-OR-TIME formats defined in vCard specification.
+        /// See <a href="https://tools.ietf.org/html/rfc6350#section-4.3.4">https://tools.ietf.org/html/rfc6350#section-4.3.4</a>
+        /// </summary>
+        private readonly static string[] _acceptedDateTimeFormats =
+            new[]
+        {
+            "o",
+            "s",
+            "yyyyMMddTHHmmssZ",
+            "yyyyMMddTHHmmss",
+            "yyyyMMdd",
+            "yyyy-MM-ddTHH:mm:ssZ",
+            "yyyy-MM-dd",
+            "yyyy-MM",
+            "yyyy",
+            "THHmmss-ffff",
+            "THHmmssZ",
+            "THHmmss",
+            "THHmm",
+            "THH",
+            "T-mmss",
+            "T--ss",
+            "--MMddTHHmmssZ",
+            "--MMddTHHmm",
+            "--MMdd",
+            "---ddTHH",
+            "---dd"
+        };
+
         public static string Serialize(DateTime? value, string key, VCardVersion version)
         {
             string serializedValue = value?.ToString("o") ?? string.Empty;
@@ -18,7 +48,12 @@ namespace MixERP.Net.VCards.Processors
         {
             DateTime parsed;
 
-            if (DateTime.TryParseExact(value, new[] {"o", "s", "yyyy-MM-ddTHH:mm:ssZ", "yyyy-MM-dd"}, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out parsed))
+            if (DateTime.TryParseExact(
+                value,
+                _acceptedDateTimeFormats,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind,
+                out parsed))
             {
                 return parsed;
             }
@@ -26,4 +61,5 @@ namespace MixERP.Net.VCards.Processors
             return null;
         }
     }
+
 }


### PR DESCRIPTION
Included support for parsing DateTimes using the DATE-AND-OR-TIME formats specified here:
https://tools.ietf.org/html/rfc6350#section-4.3.4">https://tools.ietf.org/html/rfc6350#section-4.3.4. 

- What led me here was the omission of what seems to be among the most commonly used date formats in vCards -- `yyyyMMdd`. At least, all of my vCards use this format for `BDAY`.
- I didn't remove any of the existing formats, although some of them do not appear in the vCard spec.