### PR TITLE
Fixed VCardHelper.cs

### DIFF
--- a/src/MixERP.Net.VCards/Helpers/VCardHelper.cs
+++ b/src/MixERP.Net.VCards/Helpers/VCardHelper.cs
@@ -6,7 +6,16 @@ namespace MixERP.Net.VCards.Helpers
     {
         public static string[] SplitCards(string contents)
         {
-            return Regex.Split(contents, "((BEGIN:VCARD)(.*)(END:VCARD))");
+            var rx = new Regex("BEGIN:VCARD(?s)(.*?)END:VCARD");
+            var matches = rx.Matches(contents);
+            var cards = new string[matches.Count];
+
+            for (var i = 0; i < matches.Count; i++)
+            {
+                cards[i] = matches[i].ToString();
+            }
+
+            return cards;
         }
     }
 }


### PR DESCRIPTION
Regex.Split didn't split the cards.  I updated the regex pattern to match each VCARD in the contents and get the matches.  There may be a better way to do this, but this works and is quite fast.